### PR TITLE
Handle a situation where there are no upcoming events

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -8,7 +8,11 @@
 - name: Who are we
   link: /team/
 - name: Where we were
+  link: /eventspast/
+  condition: past
+- name: Where we'll be
   link: /events/
+  condition: future
 # This can be added back in when we have blog posts
 #- name: Blog
 # link: /blog/

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -30,7 +30,29 @@
                         </div>
                     </div>
                     {% else %}
-                    <a href="{{ item.link | relative_url }}" class="navbar-item {% if item.link == page.url %}is-active{% endif %}">{{ item.name }}</a>
+                        {% assign show_item = true %}                        
+                        {% if item.condition %}
+                            {% assign showcase_name = 'events_showcase' %}
+                            {% assign last_event = site.data.[showcase_name].items | sort:"dateval" | reverse | first %}
+                            
+                            {% assign today_date = 'now' | date: '%s' %}
+                            {% assign last_date = last_event.dateval | date: '%s' %}
+
+                            {% if item.condition == "future" %}
+                                {% if last_date < today_date %}
+                                    {% assign show_item = false %}
+                                {% endif %}
+                            {% endif %}
+                            {% if item.condition == "past" %}
+                                {% if last_date >= today_date %}
+                                    {% assign show_item = false %}
+                                {% endif %}
+                            {% endif %}
+
+                        {% endif %}    
+                        {% if show_item == true %}
+                            <a href="{{ item.link | relative_url }}" class="navbar-item {% if item.link == page.url %}is-active{% endif %}">{{ item.name }}</a>
+                        {% endif %}    
                     {% endif %}
                 {% endfor %}
                 {% endif %}

--- a/events.md
+++ b/events.md
@@ -10,3 +10,5 @@ sort: year
 show_events: future
 hero_height: is-small
 ---
+
+#### That's all for now but check out the [list of events that we were previously at](/eventspast)!


### PR DESCRIPTION
This change does the following:

* Adds a note to the bottom of the upcoming events page which directs people to the past events page. This will always appear so appear as the only item on the page if there are no upcoming events.
* Changes the header menu so that if there are no upcoming events, it defaults to the past events instead.