### PR TITLE
Silence Dart Sass deprecation warnings from Bulma theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -84,6 +84,15 @@ collections:
 #   - vendor/gems/
 #   - vendor/ruby/
 
+sass:
+  quiet_deps: true
+  silence_deprecations:
+    - import
+    - global-builtin
+    - color-functions
+    - mixed-decls
+    - if-function
+
 exclude:
     - README.md
     - localrun.bat


### PR DESCRIPTION
## Summary
- Adds `sass` config to `_config.yml` to silence ~263 Dart Sass deprecation warnings originating from Bulma 0.x code inside the bulma-clean-theme gem
- Uses `quiet_deps: true` and `silence_deprecations` for: `import`, `global-builtin`, `color-functions`, `mixed-decls`, `if-function`
- No visual changes — this only suppresses warnings during build, the CSS output is identical

## Test plan
- [x] Run `bundle exec jekyll serve --future` and confirm deprecation warnings are gone
- [ ] Verify site renders correctly with no visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)