### PR TITLE
Add dedicated AGHAST product page

### DIFF
--- a/.github/workflows/local-custom.txt
+++ b/.github/workflows/local-custom.txt
@@ -59,3 +59,6 @@ SARIF
 pluggability
 aghastbouncecaption
 Evron
+vcentered
+aghastbouncesmaller
+crosshairs

--- a/_data/aghast_callout.yml
+++ b/_data/aghast_callout.yml
@@ -1,15 +1,19 @@
 # Search here: https://fontawesome.com/v5/search?q=people&o=r&m=free
 style: is-light
 height: is-small
+intro: >
+  You know what your key code security concerns are. But how do you check for them in a way
+  that is automatable, repeatable and scalable? AGHAST is an open-source framework that lets
+  you define and check for these concerns.
 items:
   - title: Custom Security Checks
     icon: fa-shield-alt
     description: >
-      Define checks specific to your codebase and organization, not just generic vulnerability patterns
+      Define logic tests specific to your codebase and organization, not just generic vulnerability patterns
   - title: Hybrid Analysis
     icon: fa-project-diagram
     description: >
-      Combine the precision of static rules with the intelligence of AI-powered code analysis
+      Combine the efficient precision of static rules with the flexible intelligence of AI-powered code analysis
   - title: Open Source
     icon: fa-code-branch
     description: >

--- a/_data/aghast_callout.yml
+++ b/_data/aghast_callout.yml
@@ -1,0 +1,16 @@
+# Search here: https://fontawesome.com/v5/search?q=people&o=r&m=free
+style: is-light
+height: is-small
+items:
+  - title: Custom Security Checks
+    icon: fa-shield-alt
+    description: >
+      Define checks specific to your codebase and organization, not just generic vulnerability patterns
+  - title: Hybrid Analysis
+    icon: fa-project-diagram
+    description: >
+      Combine the precision of static rules with the intelligence of AI-powered code analysis
+  - title: Open Source
+    icon: fa-code-branch
+    description: >
+      Free to use, extend, and integrate into your existing security workflows

--- a/_data/aghast_features.yml
+++ b/_data/aghast_features.yml
@@ -3,7 +3,7 @@
     Works with your existing code as-is. No need to add annotations, modify source files, or build anything into your codebase.
 - title: Language Agnostic
   description: >
-    Write your checks in plain language and simple configuration. You don't need to write rules in the language of the codebase being scanned.
+    Use natural language to instruct the AI provider and a standard, language-agnostic static rule language for discovery.
 - title: CI Pipeline Ready
   description: >
     Designed from the start for automated CI pipelines with a simple install process, text-based configuration, and a single CLI call to run.

--- a/_data/aghast_features.yml
+++ b/_data/aghast_features.yml
@@ -1,0 +1,18 @@
+- title: No Codebase Modifications Required
+  description: >
+    Works with your existing code as-is. No need to add annotations, modify source files, or build anything into your codebase.
+- title: Language Agnostic
+  description: >
+    Write your checks in plain language and simple configuration. You don't need to write rules in the language of the codebase being scanned.
+- title: CI Pipeline Ready
+  description: >
+    Designed from the start for automated CI pipelines with a simple install process, text-based configuration, and a single CLI call to run.
+- title: Pluggable Architecture
+  description: >
+    Supports multiple discovery methods (Semgrep, OpenAnt, SARIF) and output formats (JSON, SARIF). Swap in different LLM providers or static analysis engines as needed.
+- title: Flexible Configuration
+  description: >
+    Define checks per-codebase or use a central configuration for multiple codebases. One config file can drive CI jobs across your entire organization.
+- title: Custom Security Rules
+  description: >
+    Define checks tailored to your organization's specific security concerns — from custom authorization patterns to business logic validation.

--- a/_data/aghast_modes.yml
+++ b/_data/aghast_modes.yml
@@ -1,0 +1,12 @@
+- title: AI Scanning
+  icon: fa-robot
+  description: >
+    The LLM examines your repository against your custom security instructions, analyzing the full codebase for issues you define.
+- title: Hybrid Checks
+  icon: fa-crosshairs
+  description: >
+    Static discovery tools pinpoint specific code locations, which are then independently analyzed by AI. The sweet spot for most use cases.
+- title: Static Checks
+  icon: fa-check-circle
+  description: >
+    Traditional rule-based discovery that directly maps findings without AI involvement, for when a static rule is all you need.

--- a/_data/aghast_modes.yml
+++ b/_data/aghast_modes.yml
@@ -1,12 +1,12 @@
-- title: AI Scanning
-  icon: fa-robot
-  description: >
-    The LLM examines your repository against your custom security instructions, analyzing the full codebase for issues you define.
-- title: Hybrid Checks
-  icon: fa-crosshairs
-  description: >
-    Static discovery tools pinpoint specific code locations, which are then independently analyzed by AI. The sweet spot for most use cases.
 - title: Static Checks
   icon: fa-check-circle
   description: >
     Traditional rule-based discovery that directly maps findings without AI involvement, for when a static rule is all you need.
+- title: Hybrid Checks
+  icon: fa-crosshairs
+  description: >
+    Static discovery tools pinpoint specific code locations, which are then independently analyzed by AI. The sweet spot for most use cases.
+- title: AI Scanning
+  icon: fa-robot
+  description: >
+    Your own LLM examines your repository against your custom security instructions, analyzing the full codebase for issues you define.

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,10 +1,12 @@
 - name: How we add value
   link: /#
   dropdown:
-  - name: Product Security Services  
+  - name: Product Security Services
     link: /services/
   - name: Product Security Training
     link: /training/
+  - name: AGHAST - Open Source Tool
+    link: /aghast/
 - name: Who we are
   link: /team/
 - name: Where we were

--- a/_includes/callouts.html
+++ b/_includes/callouts.html
@@ -15,6 +15,9 @@
     <section class="hero {% if callouts_height %} {{ callouts_height }} {% else %} is-medium {% endif %} {{ callouts.style }}">
         <div class="hero-body">
             <div class="container">
+                {% if callouts.intro %}
+                <p class="subtitle is-5 has-text-centered" style="margin-bottom: 2em;">{{ callouts.intro }}</p>
+                {% endif %}
                 <div class="columns is-multiline is-centered">
                     {% for callout in callouts.items %}
                         <div class="column is-4 has-text-centered">

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -1,0 +1,124 @@
+---
+layout: page
+---
+
+<div class="content">
+
+    <div class="columns is-vcentered">
+        <div class="column is-5 has-text-centered">
+            {% if page.product_image %}
+                <img src="{{ page.product_image }}" alt="{{ page.title }} logo" style="max-width: 300px;">
+            {% endif %}
+        </div>
+        <div class="column is-7">
+            {% if page.product_tagline %}
+                <p class="title is-4">{{ page.product_tagline }}</p>
+            {% endif %}
+            {{ content }}
+        </div>
+    </div>
+
+</div>
+
+{% include callouts.html %}
+
+{% if page.how_it_works %}
+<hr>
+<div class="content">
+    <h2>{{ page.how_it_works_title | default: "How It Works" }}</h2>
+    {{ page.how_it_works | markdownify }}
+
+    {% if page.how_it_works_image %}
+    <div class="columns is-centered" style="margin-top: 1.5em;">
+        <div class="column is-10 has-text-centered">
+            <img src="{{ page.how_it_works_image }}" alt="{{ page.how_it_works_image_alt | default: 'How it works' }}" style="max-width: 600px;">
+        </div>
+    </div>
+    {% endif %}
+
+    {% assign modes = site.data.[page.modes_data] %}
+    {% if modes %}
+    <div class="columns is-multiline" style="margin-top: 1em;">
+        {% for mode in modes %}
+        <div class="column is-4">
+            <div class="box">
+                <p class="title is-5 has-text-centered">
+                    {% if mode.icon %}<span class="icon"><i class="fas {{ mode.icon }}"></i></span>{% endif %}
+                    {{ mode.title }}
+                </p>
+                <p>{{ mode.description }}</p>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
+</div>
+{% endif %}
+
+{% if page.video %}
+<hr>
+<div class="content">
+    <h2>{{ page.video_title | default: "Video Introduction" }}</h2>
+    <div class="columns is-centered">
+        <div class="column is-8">
+            {% include youtube.html video=page.video %}
+        </div>
+    </div>
+</div>
+{% endif %}
+
+{% assign features = site.data.[page.features_data] %}
+{% if features %}
+<hr>
+<div class="content">
+    <h2>{{ page.features_title | default: "Key Features" }}</h2>
+    <div class="columns is-multiline" style="margin-top: 1em;">
+        {% for feature in features %}
+        <div class="column is-6">
+            <h4>{{ feature.title }}</h4>
+            <p>{{ feature.description }}</p>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+{% endif %}
+
+{% if page.questions %}
+<hr>
+<div class="content">
+    <h2>{{ page.questions_title | default: "Questions It Can Answer" }}</h2>
+    <p>{{ page.questions_intro }}</p>
+    <ul>
+        {% for question in page.questions_list %}
+        <li>{{ question }}</li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}
+
+{% if page.getting_started %}
+<hr>
+<div class="content">
+    <h2>{{ page.getting_started_title | default: "Getting Started" }}</h2>
+    {{ page.getting_started | markdownify }}
+
+    {% if page.action_buttons %}
+    <div class="buttons is-centered" style="margin-top: 1.5em;">
+        {% for button in page.action_buttons %}
+        <a href="{{ button.link }}" class="button {{ button.style | default: 'is-primary' }} is-medium" {% if button.external %}target="_blank"{% endif %}>
+            {% if button.icon %}<span class="icon"><i class="{{ button.icon }}"></i></span>{% endif %}
+            <span>{{ button.text }}</span>
+        </a>
+        {% endfor %}
+    </div>
+    {% endif %}
+</div>
+{% endif %}
+
+{% if page.licensing %}
+<hr>
+<div class="content">
+    <h2>{{ page.licensing_title | default: "Licensing" }}</h2>
+    {{ page.licensing | markdownify }}
+</div>
+{% endif %}

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -45,6 +45,19 @@ layout: page
 </div>
 {% endif %}
 
+{% if page.questions %}
+<hr>
+<div class="content">
+    <h2>{{ page.questions_title | default: "Questions It Can Answer" }}</h2>
+    <p>{{ page.questions_intro }}</p>
+    <ul>
+        {% for question in page.questions_list %}
+        <li>{{ question }}</li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}
+
 {% if page.video %}
 <hr>
 <div class="content">
@@ -70,19 +83,6 @@ layout: page
         </div>
         {% endfor %}
     </div>
-</div>
-{% endif %}
-
-{% if page.questions %}
-<hr>
-<div class="content">
-    <h2>{{ page.questions_title | default: "Questions It Can Answer" }}</h2>
-    <p>{{ page.questions_intro }}</p>
-    <ul>
-        {% for question in page.questions_list %}
-        <li>{{ question }}</li>
-        {% endfor %}
-    </ul>
 </div>
 {% endif %}
 

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -20,21 +20,11 @@ layout: page
 
 </div>
 
-{% include callouts.html %}
-
 {% if page.how_it_works %}
 <hr>
 <div class="content">
     <h2>{{ page.how_it_works_title | default: "How It Works" }}</h2>
     {{ page.how_it_works | markdownify }}
-
-    {% if page.how_it_works_image %}
-    <div class="columns is-centered" style="margin-top: 1.5em;">
-        <div class="column is-10 has-text-centered">
-            <img src="{{ page.how_it_works_image }}" alt="{{ page.how_it_works_image_alt | default: 'How it works' }}" style="max-width: 600px;">
-        </div>
-    </div>
-    {% endif %}
 
     {% assign modes = site.data.[page.modes_data] %}
     {% if modes %}

--- a/_posts/2026-04-14-Introducing-AGHAST.markdown
+++ b/_posts/2026-04-14-Introducing-AGHAST.markdown
@@ -9,7 +9,7 @@ author: josh
 image: /assets/img/2026-04-aghast-intro/aghastbouncecaption.png
 summary: Introducing AGHAST, an open source framework that combines static discovery with AI prompts to find code-specific and company-specific security issues.
 redirect_from:
-  - /aghast
+  - /aghast-blog
 ---
 
 #### tl;dr

--- a/aghast.md
+++ b/aghast.md
@@ -29,8 +29,9 @@ questions_list:
   - Are API endpoints returning too wide a data set?
   - Are there places where our internal security patterns have been bypassed?
 getting_started: >
-  AGHAST requires **Node.js 20+** and an **Anthropic API key** for AI-powered checks.
-  Optional components include Semgrep Community Edition and OpenAnt for additional discovery methods.
+  AGHAST requires **Node.js 20+**. Depending on the check modes you use, you will also need
+  an **Anthropic API key** (for AI and hybrid checks) and/or **Semgrep Community Edition**
+  (for hybrid and static checks). **OpenAnt** is supported as an alternative discovery method.
 action_buttons:
   - text: View on GitHub
     link: https://github.com/BounceSecurity/aghast

--- a/aghast.md
+++ b/aghast.md
@@ -1,0 +1,64 @@
+---
+title: "AGHAST"
+subtitle: "AI-Guided Hybrid Application Static Testing"
+layout: product
+show_sidebar: false
+hero_height: is-small
+hero_link: https://github.com/BounceSecurity/aghast
+hero_link_text: Get Started on GitHub
+hero_link_colour: is-dark
+hero_link_size: is-medium
+callouts: aghast_callout
+product_image: /assets/img/2026-04-aghast-intro/aghastbouncesmaller.png
+product_tagline: Find the issues that generic scanners miss
+modes_data: aghast_modes
+features_data: aghast_features
+video: B76A33l1LyI
+how_it_works_title: How It Works
+how_it_works: >
+  AGHAST uses a **hybrid approach**: static rules narrow down the areas of interest in your codebase,
+  then AI examines those specific areas in depth. Think of it as a metal detector on a beach —
+  the static rule tells you where to dig, and the AI carefully examines what you find.
+
+
+  AGHAST supports three modes of operation:
+how_it_works_image: /assets/img/2026-04-aghast-intro/funnel.png
+how_it_works_image_alt: "AGHAST hybrid approach: static rules filter code, AI analyzes findings"
+questions: true
+questions_title: The Questions AGHAST Can Answer
+questions_intro: >
+  Unlike generic scanners that look for known vulnerability patterns, AGHAST helps you answer
+  organization-specific questions:
+questions_list:
+  - Has our custom business verification been implemented correctly?
+  - Has the company's custom authorization mechanism been used correctly and consistently?
+  - Are API endpoints returning too wide a data set?
+  - Are there places where our internal security patterns have been bypassed?
+getting_started: >
+  AGHAST requires **Node.js 20+** and an **Anthropic API key** for AI-powered checks.
+  Optional components include Semgrep Community Edition and OpenAnt for additional discovery methods.
+action_buttons:
+  - text: View on GitHub
+    link: https://github.com/BounceSecurity/aghast
+    icon: fab fa-github
+    style: is-primary
+    external: true
+  - text: Read the Blog Post
+    link: /blog/2026/04/12/Introducing-AGHAST.html
+    icon: fas fa-newspaper
+    style: is-info
+  - text: Get in Touch
+    link: "mailto:info@bouncesecurity.com?subject=AGHAST"
+    icon: fas fa-envelope
+    style: is-dark
+licensing: >
+  AGHAST is licensed under **AGPL** to keep it open and ensure improvements flow back to the community.
+  If you are interested in commercial licensing, professional support, or help implementing AGHAST
+  in your organization, [get in touch](mailto:info@bouncesecurity.com?subject=AGHAST%20Commercial%20Licensing).
+---
+
+**AGHAST** is an open source framework that combines static code discovery with AI-powered analysis to find **codebase-specific** and **company-specific** security issues.
+
+Generic scanners catch generic bugs. But what about your custom authorization logic? Your business-specific validation rules? The security patterns unique to your organization? AGHAST is built to answer those questions.
+
+These are questions that require **context** about how things *should* work, not just what is technically vulnerable.

--- a/aghast.md
+++ b/aghast.md
@@ -19,10 +19,10 @@ how_it_works: >
   AGHAST is a framework for orchestrating custom security checks against your codebase.
   It supports three modes of operation, allowing you to choose the right approach for each check:
 questions: true
-questions_title: The Questions AGHAST Can Answer
+questions_title: Example Questions AGHAST Can Answer
 questions_intro: >
   Unlike generic scanners that look for known vulnerability patterns, AGHAST helps you answer
-  organization-specific questions:
+  organization-specific questions such as:
 questions_list:
   - Has our custom business verification been implemented correctly?
   - Has the company's custom authorization mechanism been used correctly and consistently?
@@ -39,7 +39,7 @@ action_buttons:
     style: is-primary
     external: true
   - text: Read the Blog Post
-    link: /blog/2026/04/12/Introducing-AGHAST.html
+    link: /blog/2026/04/14/Introducing-AGHAST.html
     icon: fas fa-newspaper
     style: is-info
   - text: Get in Touch

--- a/aghast.md
+++ b/aghast.md
@@ -16,12 +16,8 @@ features_data: aghast_features
 video: B76A33l1LyI
 how_it_works_title: How It Works
 how_it_works: >
-  AGHAST uses a **hybrid approach**: static rules narrow down the areas of interest in your codebase,
-  then AI examines those specific areas in depth. Think of it as a metal detector on a beach —
-  the static rule tells you where to dig, and the AI carefully examines what you find.
-
-
-  AGHAST supports three modes of operation:
+  AGHAST is a framework for orchestrating custom security checks against your codebase.
+  It supports three modes of operation, allowing you to choose the right approach for each check:
 questions: true
 questions_title: The Questions AGHAST Can Answer
 questions_intro: >

--- a/aghast.md
+++ b/aghast.md
@@ -22,8 +22,6 @@ how_it_works: >
 
 
   AGHAST supports three modes of operation:
-how_it_works_image: /assets/img/2026-04-aghast-intro/funnel.png
-how_it_works_image_alt: "AGHAST hybrid approach: static rules filter code, AI analyzes findings"
 questions: true
 questions_title: The Questions AGHAST Can Answer
 questions_intro: >


### PR DESCRIPTION
## Summary
- Adds a new product page for AGHAST at `/aghast/` with hero, callout cards, feature grid, video embed, and CTA buttons
- Creates a reusable `product` layout (`_layouts/product.html`) that separates formatting from content, driven by front matter and data files
- Adds data files for callout cards (`aghast_callout.yml`), feature grid (`aghast_features.yml`), and operating modes (`aghast_modes.yml`)
- Adds AGHAST to the "How we add value" navigation dropdown
- Changes the blog post `redirect_from: /aghast` to `/aghast-blog` so the product page can use `/aghast/`
- Adds cspell dictionary entries for Bulma CSS classes and FontAwesome icon names

## Test plan
- [ ] Run `bundle exec jekyll serve --future` and verify `/aghast/` renders correctly
- [ ] Verify the hero section, callout cards, how-it-works section, video, features grid, questions list, action buttons, and licensing section all display properly
- [ ] Verify the "How we add value" dropdown includes the AGHAST link
- [ ] Verify `/aghast-blog` redirects to the blog post
- [ ] Verify the "Read the Blog Post" button links to the correct blog post URL
- [ ] Test on mobile/tablet for responsive layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)