### PR TITLE
Add full course outline for Black Hat

### DIFF
--- a/_training/aisast.md
+++ b/_training/aisast.md
@@ -10,6 +10,8 @@ redirect_from:
     - /training-courses/aisast
 ---
 
+### Introduction
+
 This hands-on course is a deep dive into combining AI-driven and deterministic techniques for scalable, repeatable code security scanning. You will learn to proactively detect and prevent vulnerabilities across multiple repositories without slowing down development.
 
 It features our purpose built, open-source tool [AGHAST](/aghast.html)!

--- a/_training/aisast.md
+++ b/_training/aisast.md
@@ -10,6 +10,10 @@ redirect_from:
     - /training-courses/aisast
 ---
 
+This hands-on course is a deep dive into combining AI-driven and deterministic techniques for scalable, repeatable code security scanning. You will learn to proactively detect and prevent vulnerabilities across multiple repositories without slowing down development.
+
+It features our purpose built, open-source tool [AGHAST](/aghast.html)!
+
 ### High level course explanation
 
 Suddenly anyone and everyone in your organization can use AI assistants to write code. Meanwhile, your actual developers are putting out 100x their previous output , with “varying” levels of quality. So how are you going to secure code at this scale?

--- a/aghast.md
+++ b/aghast.md
@@ -32,6 +32,9 @@ getting_started: >
   AGHAST requires **Node.js 20+**. Depending on the check modes you use, you will also need
   an **Anthropic API key** (for AI and hybrid checks) and/or **Semgrep Community Edition**
   (for hybrid and static checks). **OpenAnt** is supported as an alternative discovery method.
+
+
+  AGHAST is heavily used in our [Repeatable, Scalable and Valuable Code Security Scanning](/training/aisast/) training course, where you will get hands-on experience writing custom checks and applying AGHAST to real-world code security challenges.
 action_buttons:
   - text: View on GitHub
     link: https://github.com/BounceSecurity/aghast

--- a/training/aisast/topics.md
+++ b/training/aisast/topics.md
@@ -51,5 +51,55 @@ The Black Hat version of this course "Achieving Scalable Code Security Scanning 
 - The practical knowledge of how to build these into a scalable process across many codebases.
 - The approach to getting code security scanning rolled out at the organizational level.
 
+### Detailed Course Outline (Black Hat version)
+
+**[Back to top ↑](#top)**
+
+**COURSE OVERVIEW**
+
+* Overview - Setup training, share training goals and detailed agenda.
+
+**INTRO TO CODE SCANNING**
+
+* What is SAST - Detailed introduction to SAST including the different techniques to be discussed in the course (generic, custom or AI powered) and their strengths and weaknesses
+* What to use and when - Review the reasoning for which technique is most efficient for different situations from a cost/effort/benefit perspective.
+* Organizational processes for SAST - Organizational considerations for rolling out any type of SAST, the stakeholders who will need to be involved, the business processes which will be needed and the expectations which must be set.
+* Exercise - SAST process - Introduce the simulated organization to be used in the exercises and use our guidance template to prepare a plan for integrating a SAST strategy into a simulated organization.
+
+**GENERIC STATIC APPLICATION SECURITY TESTING**
+
+* What is Generic SAST - Some more specific explanation on what we mean by Generic SAST and how it would generally be automated.
+* Addressing Generic SAST findings - Understand the various considerations for addressing Generic SAST findings including eliminating noise and how best to remediate, including effective AI prompts for triage
+* Exercise - Evaluating Generic SAST findings - Practice evaluating SAST findings according to considerations above. Prepare mitigation and prioritization advice and explanations.
+
+**CUSTOM STATIC APPLICATION SECURITY TESTING**
+
+* Intro to custom SAST - Some initial examples of custom tests and rule languages that can be used (such as lint, Semgrep, CodeQL) and an intro to the rule language we will be focusing on (Semgrep) and why.
+* Similar patterns and limiting search - How to find simple, but significant, patterns in the code whilst narrowing down results to avoid false positives - PLUS hands-on practice exercises using examples related to this
+* Writing rules from scratch for root cause analysis - Learn how to write rules from a blank state and using them to track flow of tainted data across the code and how to find the common cause PLUS hands-on practice exercises using examples related to this
+* Broad system analysis with multi function/file rules - How to use the CLI and combine everything learned so far on the scale of the whole app – mapping entry points, tracking flows, detecting missing security mechanisms. Start using AI assistants to help develop Semgrep rules as well.
+* Summary exercise - Summary exercise covering everything learnt so far
+
+**INTRO TO AI CODE SECURITY SCANNING**
+
+* Introduction to AI and Code Scanning - Starting with a general overview and then moving into some key principles for writing rules, a discussion of which platforms and models to use and also some security considerations. 
+* AI Assistant hands-on - Initial short exercise to practice using AI coding assistants.
+* AI Rules - Initial prompt and basic rules - Guidance around developing a system prompt and then the structure of a standard rule PLUS an exercise to practice this.
+
+**COMPLEX AI CODE SECURITY SCANNING**
+
+* Complex rules - Reviewing generic SAST - How to use AI to review and triage generic SAST findings PLUS an exercise to practice this.
+* Complex rules - Combined static/AI - Creating multi-stage rules that start with a static test and then use the results to perform specific analysis PLUS an exercise to practice this.
+* Complex rules - RAG/Context based - Rules that use RAG to provide additional context to the LLM when performing analysis PLUS an exercise to practice this.
+* Market survey - Briefly compare current offering types with the techniques being discussed here, group products by functionality and approach.
+
+**INTEGRATING INTO CI**
+
+* Integrating Customized Tests into CI Pipelines - Running repository focused custom tests (static and AI based), potential CI integration architectures, scan configurations and output formats.
+* CI scan example - Brief example of what to consider when integrating into CI using the simulated organization.
+
+**SUMMARY**
+
+* Course Summary - Summarize course content and key takeaways.
 
 **[Back to top ↑](#top)**

--- a/training/aisast/topics.md
+++ b/training/aisast/topics.md
@@ -55,6 +55,8 @@ The Black Hat version of this course "Achieving Scalable Code Security Scanning 
 
 **[Back to top ↑](#top)**
 
+[Register here for the Black Hat course](https://appsecg.host/bhreg)
+
 **COURSE OVERVIEW**
 
 * Overview - Setup training, share training goals and detailed agenda.
@@ -101,5 +103,7 @@ The Black Hat version of this course "Achieving Scalable Code Security Scanning 
 **SUMMARY**
 
 * Course Summary - Summarize course content and key takeaways.
+
+[Register here for the Black Hat course](https://appsecg.host/bhreg)
 
 **[Back to top ↑](#top)**


### PR DESCRIPTION
## Summary
- Adds complete course outline/topics page for the AI SAST training course (`training/aisast/topics.md`)

## Test plan
- [ ] Verify the topics page renders correctly at `/training/aisast/topics/`
- [ ] Check sidebar navigation works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)